### PR TITLE
Stopped ex from clearing terminal.

### DIFF
--- a/vi.c
+++ b/vi.c
@@ -2109,9 +2109,10 @@ int main(int argc, char *argv[])
 			ex();
 		ex_done();
 	}
-	if (xled || xvis)
+	if (xvis) {
 		term_done();
-	term_clean();
+		term_clean();
+	}
 	vi_regdone();
 	syn_done();
 	dir_done();


### PR DESCRIPTION
When I run a strict CLI editor, I do not want it
to clear the whole screen when I quit. There is
no need for it as both the editor and the shell
are CLI and not TUI.