### PR TITLE
Prevent buffer over-read when s is an empty string

### DIFF
--- a/ex.c
+++ b/ex.c
@@ -1072,7 +1072,7 @@ void ex_init(char **files, int n)
 	do {
 		ec_edit("", "e", s);
 		s = *(++files);
-	} while (s);
+	} while (--n > 0);
 	if (xled && (s = getenv("EXINIT")))
 		ex_command(s)
 }


### PR DESCRIPTION
argv ends with a null pointer.
A pointer to a random string does not.