### PR TITLE
add support for option blocks

### DIFF
--- a/vi.c
+++ b/vi.c
@@ -2014,7 +2014,7 @@ static int setup_signals(void) {
 
 int main(int argc, char *argv[])
 {
-	int i;
+	int i,j;
 	if (!setup_signals())
 		return 1;
 	dir_init();
@@ -2022,16 +2022,18 @@ int main(int argc, char *argv[])
 	temp_open(0, "/hist/", "/");
 	temp_open(1, "/fm/", "/fm");
 	for (i = 1; i < argc && argv[i][0] == '-'; i++) {
-		if (argv[i][1] == 's' && !argv[i][2])
-			xvis |= 2;
-		else if (argv[i][1] == 'e' && !argv[i][2])
-			xvis |= 4;
-		else if (argv[i][1] == 'v' && !argv[i][2])
-			xvis = 0;
-		else {
-			fprintf(stderr, "Unknown option: %s\n", argv[i]);
-			fprintf(stderr, "Usage: %s [-e] [-s] [-v] [file ...]\n", argv[0]);
-			return 1;
+		for (j = 1; argv[i][j]; j++) {
+			if (argv[i][j] == 's')
+				xvis |= 2;
+			else if (argv[i][j] == 'e')
+				xvis |= 4;
+			else if (argv[i][j] == 'v')
+				xvis = 0;
+			else {
+				fprintf(stderr, "Unknown option: -%c\n", argv[i][j]);
+				fprintf(stderr, "Usage: %s [-esv] [file ...]\n", argv[0]);
+				return 1;
+			}
 		}
 	}
 	term_init();

--- a/vi.c
+++ b/vi.c
@@ -2022,6 +2022,10 @@ int main(int argc, char *argv[])
 	temp_open(0, "/hist/", "/");
 	temp_open(1, "/fm/", "/fm");
 	for (i = 1; i < argc && argv[i][0] == '-'; i++) {
+		if (argv[i][1] == '-' && !argv[i][2]) {
+			i++;
+			break;
+		}
 		for (j = 1; argv[i][j]; j++) {
 			if (argv[i][j] == 's')
 				xvis |= 2;


### PR DESCRIPTION
without using getopt

`vi -es` is the same as `vi -e -s`

also stops parsing args after --, so someone could edit files starting with - using `vi -- -file`