### PR TITLE
Improvements to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,15 +7,17 @@ CFLAGS="\
 -Wfatal-errors -std=c99 \
 -D_POSIX_C_SOURCE=200809L $CFLAGS"
 
-: ${CC:=$(command -v cc)}
-: ${PREFIX:=/usr/local}
-OS="$(uname)"
-case "$OS" in *BSD*) CFLAGS="$CFLAGS -D_BSD_SOURCE" ;; esac
-case "$OS" in *Darwin*) CFLAGS="$CFLAGS -D_DARWIN_C_SOURCE" ;; esac
+: "${CC:=cc}"
+: "${PREFIX:=/usr/local}"
+: "${OS:=$(uname)}"
+case "$OS" in
+    *BSD*)    CFLAGS="$CFLAGS -D_BSD_SOURCE"      ;;
+    *Darwin*) CFLAGS="$CFLAGS -D_DARWIN_C_SOURCE" ;;
+esac
 
 run() {
 	printf '%s\n' "$*"
-	eval "$@"
+	eval "$*"
 }
 
 install() {
@@ -32,7 +34,7 @@ pgobuild() {
 	run "$CC vi.c -fprofile-generate=. -o vi $CFLAGS"
 	echo "qq" | ./vi -v ./vi.c >/dev/null
 	run "$CC vi.c -fprofile-use=. -o vi $CFLAGS"
-	rm *.gcda
+	rm ./*.gcda
 }
 
 if [ "$#" -gt 0 ]; then

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ CFLAGS="\
 -Wno-missing-field-initializers \
 -Wno-unused-parameter \
 -Wfatal-errors -std=c99 \
--D_POSIX_C_SOURCE=200809L $CFLAGS"
+-D_POSIX_C_SOURCE=200809L -O2 $CFLAGS"
 
 : "${CC:=cc}"
 : "${PREFIX:=/usr/local}"

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ CFLAGS="\
 -Wno-implicit-fallthrough \
 -Wno-missing-field-initializers \
 -Wno-unused-parameter \
+-Wno-unused-result \
 -Wfatal-errors -std=c99 \
 -D_POSIX_C_SOURCE=200809L -O2 $CFLAGS"
 


### PR DESCRIPTION
lines 20 and 37 are to fix shellcheck warnings, [SC2294](https://www.shellcheck.net/wiki/SC2294) and [SC2035](https://www.shellcheck.net/wiki/SC2035)

quoting lines 10 and 11 fixes [SC2223](https://www.shellcheck.net/wiki/SC2223)

line 10 doesn't run `command -v` anymore, I'm not sure why it did in the first place

line 12 was changed so users can specify their own OS, makes cross compiling slightly easier

the 2 case statements were squished into 1, I'm not sure what the point of having 2 case statements was, were you hoping to catch a potential `Darwin BSD` OS?

O2 optimizations should be a no-brainer