### PR TITLE
add .bash and .zsh extentions to shell script syntax

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -10,7 +10,7 @@ struct filetype fts[] = {
 	{"tex", "\\.tex$"},				/* tex */
 	{"msg", "letter$|mbox$|mail$"},			/* email */
 	{"mk", "Makefile$|makefile$|\\.mk$"},		/* makefile */
-	{"sh", "\\.sh$"},				/* shell script */
+	{"sh", "\\.(sh|bash|zsh)$"},			/* shell script */
 	{"py", "\\.py$"},				/* python */
 	{"nm", "\\.nm$"},				/* neatmail */
 	{"js", "\\.js$"},				/* javascript */


### PR DESCRIPTION
from the small amount of testing I've done, bash and zsh syntax highlighting works fine