### PR TITLE
add filetypes to filetype_shebang patch

### DIFF
--- a/filetype_shebang.patch
+++ b/filetype_shebang.patch
@@ -1,5 +1,5 @@
 diff --git a/ex.c b/ex.c
-index 5b39040..a85dafe 100644
+index 5b39040..222d3ce 100644
 --- a/ex.c
 +++ b/ex.c
 @@ -418,6 +418,16 @@ static int ec_edit(char *loc, char *cmd, char *arg)
@@ -10,8 +10,8 @@ index 5b39040..a85dafe 100644
 +		int adv = 0;
 +		while (lbuf_len(xb) >= adv && lbuf_buf(xb)[adv][0] == '\n')
 +			adv++;
-+		char *langs[] = {"/bin/sh", "/bin/python"};
-+		char *types[] = {"sh", "py"};
++		char *langs[] = {"/bin/sh", "/bin/dash", "/bin/bash", "/bin/zsh", "/usr/bin/env sh", "/usr/bin/env dash", "/usr/bin/env bash", "/usr/bin/env zsh", "/bin/python", "/usr/bin/env python"};
++		char *types[] = {"sh", "sh", "sh", "sh", "sh", "sh", "sh", "sh", "py", "py"};
 +		for (int i = 0; i < LEN(langs); i++)
 +			if (strstr(lbuf_buf(xb)[adv], langs[i]))
 +				ex_ft = syn_setft(types[i]);


### PR DESCRIPTION
Obviously this is very ugly, that's why it's a draft pr for now, I wanna share ideas for making it less ugly

My first attempt at this had a way to automatically generate those strings, but it was bad. It just ran snprintf twice for every filetype.  Too complex to actually use IMO

Ideally something could be done at compile time, but I'm not good enough at C to do that