### PR TITLE
clang pgobuild: fix for macos

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ pgobuild() {
 	fi
 	run "$CC vi.c -fprofile-generate=. -o vi $CFLAGS"
 	echo "qq" | ./vi -v ./vi.c >/dev/null
-	[ "$clang" -eq 1 ] && run "$PROFDATA" merge ./*.profraw -o default.profdata
+	[ "$clang" = 1 ] && run "$PROFDATA" merge ./*.profraw -o default.profdata
 	run "$CC vi.c -fprofile-use=. -o vi $CFLAGS"
 	rm -f ./*.gcda ./*.profraw ./default.profdata
 }

--- a/build.sh
+++ b/build.sh
@@ -32,10 +32,19 @@ build() {
 }
 
 pgobuild() {
+	ccversion="$($CC --version)"
+	case "$ccversion" in *clang*) clang=1 ;; esac
+	if [ "$clang" -eq 1 ]; then
+		if command -v llvm-profdata >/dev/null 2>&1; then
+			PROFDATA=llvm-profdata
+		elif xcrun -f llvm-profdata >/dev/null 2>&1; then
+			PROFDATA="xcrun llvm-profdata"
+		fi
+		[ -z "$PROFDATA" ] && echo "pgobuild with clang requires llvm-profdata" && exit 1
+	fi
 	run "$CC vi.c -fprofile-generate=. -o vi $CFLAGS"
 	echo "qq" | ./vi -v ./vi.c >/dev/null
-	ccversion="$("$CC" --version)"
-	case "$ccversion" in *clang*) run llvm-profdata merge ./*.profraw -o default.profdata ;; esac
+	[ "$clang" -eq 1 ] && run "$PROFDATA" merge ./*.profraw -o default.profdata
 	run "$CC vi.c -fprofile-use=. -o vi $CFLAGS"
 	rm -f ./*.gcda ./*.profraw ./default.profdata
 }

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ build() {
 pgobuild() {
 	ccversion="$($CC --version)"
 	case "$ccversion" in *clang*) clang=1 ;; esac
-	if [ "$clang" -eq 1 ]; then
+	if [ "$clang" = 1 ]; then
 		if command -v llvm-profdata >/dev/null 2>&1; then
 			PROFDATA=llvm-profdata
 		elif xcrun -f llvm-profdata >/dev/null 2>&1; then


### PR DESCRIPTION
Apple doesn't link llvm-* tools into PATH by default, they provide a tool called `xcrun` to use those tools.  I didn't notice in my testing because I use a more up to date LLVM installation from homebrew and put that in my PATH and didn't think to remove it.