### PR TITLE
filetype_shebang.patch: catch extra options

### DIFF
--- a/filetype_shebang.patch
+++ b/filetype_shebang.patch
@@ -1,5 +1,5 @@
 diff --git a/ex.c b/ex.c
-index 0b79349..0071977 100644
+index 0b79349..777f910 100644
 --- a/ex.c
 +++ b/ex.c
 @@ -417,6 +417,23 @@ static int ec_edit(char *loc, char *cmd, char *arg)
@@ -12,7 +12,7 @@ index 0b79349..0071977 100644
 +			adv++;
 +		struct filetype lfts[] = {
 +			{"sh", "^#!/.*/(env )?(sh|bash|zsh|dash)( .*)?$"},
-+			{"py", "^#!/.*/(env )?(python)( .*)?$"}
++			{"py", "^#!/.*/(env )?(python3?)( .*)?$"}
 +		};
 +		char *pats[LEN(lfts)];
 +		for (int i = 0; i < LEN(lfts); i++)

--- a/filetype_shebang.patch
+++ b/filetype_shebang.patch
@@ -1,5 +1,5 @@
 diff --git a/ex.c b/ex.c
-index 0b79349..aa47ae2 100644
+index 0b79349..0071977 100644
 --- a/ex.c
 +++ b/ex.c
 @@ -417,6 +417,23 @@ static int ec_edit(char *loc, char *cmd, char *arg)
@@ -11,8 +11,8 @@ index 0b79349..aa47ae2 100644
 +		while (lbuf_len(xb) >= adv && lbuf_buf(xb)[adv][0] == '\n')
 +			adv++;
 +		struct filetype lfts[] = {
-+			{"sh", "^#!/.*/(env )?(sh|bash|zsh|dash)$"},
-+			{"py", "^#!/.*/(env )?(python)$"}
++			{"sh", "^#!/.*/(env )?(sh|bash|zsh|dash)( .*)?$"},
++			{"py", "^#!/.*/(env )?(python)( .*)?$"}
 +		};
 +		char *pats[LEN(lfts)];
 +		for (int i = 0; i < LEN(lfts); i++)


### PR DESCRIPTION
Sometimes shebangs pass options to whatever program they use, for example some shell scripts use `#!/bin/sh -x`, this should catch those.

I also made the python shebang catch python3

I don't have much experience with non-trivial regex so let me know if there's some better way to do this.