### PR TITLE
allow user to specify llvm-profdata command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ build() {
 pgobuild() {
 	ccversion="$($CC --version)"
 	case "$ccversion" in *clang*) clang=1 ;; esac
-	if [ "$clang" = 1 ]; then
+	if [ "$clang" = 1 ] && [ -z "$PROFDATA" ]; then
 		if command -v llvm-profdata >/dev/null 2>&1; then
 			PROFDATA=llvm-profdata
 		elif xcrun -f llvm-profdata >/dev/null 2>&1; then


### PR DESCRIPTION
I added this because I had one version of LLVM in my $PATH but wanted to use another version for the build, since we already have a variable for the llvm-profdata command, just check if it already has something in it and leave it alone if it does