### PR TITLE
highlight more shell scripts

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -10,7 +10,7 @@ struct filetype fts[] = {
 	{"tex", "\\.tex$"},				/* tex */
 	{"msg", "letter$|mbox$|mail$"},			/* email */
 	{"mk", "Makefile$|makefile$|\\.mk$"},		/* makefile */
-	{"sh", "\\.(sh|bash|zsh)$"},			/* shell script */
+	{"sh", "\\.(ba|z)?sh$|(ba|z|k)shrc$|profile$"},	/* shell script */
 	{"py", "\\.py$"},				/* python */
 	{"nm", "\\.nm$"},				/* neatmail */
 	{"js", "\\.js$"},				/* javascript */

--- a/conf.c
+++ b/conf.c
@@ -9,7 +9,7 @@ struct filetype fts[] = {
 	{"roff", "\\.(ms|tr|roff|tmac|txt|[1-9])$"},	/* troff */
 	{"tex", "\\.tex$"},				/* tex */
 	{"msg", "letter$|mbox$|mail$"},			/* email */
-	{"mk", "Makefile$|makefile$|\\.mk$"},		/* makefile */
+	{"mk", "(M|m)akefile$|\\.mk$"},		/* makefile */
 	{"sh", "\\.(ba|z)?sh$|(ba|z|k)shrc$|profile$"},	/* shell script */
 	{"py", "\\.py$"},				/* python */
 	{"nm", "\\.nm$"},				/* neatmail */


### PR DESCRIPTION
this will apply sh syntax highlighting to bashrc, zshrc, kshrc, and any file that ends in profile (profile, bash_profile, zprofile, etc)