### PR TITLE
small fix with arguement handling

### DIFF
--- a/vi.c
+++ b/vi.c
@@ -2030,7 +2030,7 @@ int main(int argc, char *argv[])
 			else if (argv[i][j] == 'e')
 				xvis |= 4;
 			else if (argv[i][j] == 'v')
-				xvis = 0;
+				xvis &= ~4;
 			else {
 				fprintf(stderr, "Unknown option: -%c\n", argv[i][j]);
 				fprintf(stderr, "Usage: %s [-esv] [file ...]\n", argv[0]);


### PR DESCRIPTION
When -v is specified it should do the opposite of -e instead of removing all flags.

This means `vi -s -v` is the same as `vi -s`