### PR TITLE
update patches to use emalloc and erealloc

### DIFF
--- a/exrc.patch
+++ b/exrc.patch
@@ -1,5 +1,5 @@
 diff --git a/ex.c b/ex.c
-index 2c841d1..f949850 100644
+index 2c841d1..e42ee9d 100644
 --- a/ex.c
 +++ b/ex.c
 @@ -21,6 +21,7 @@ int xgrp = 2;			/* regex search group */
@@ -28,7 +28,7 @@ index 2c841d1..f949850 100644
 +	int n = 0;
 +	int c;
 +	while ((c = fgetc(fp)) != EOF && c != '\n') {
-+		ln = realloc(ln, n + 2);
++		ln = erealloc(ln, n + 2);
 +		ln[n++] = c;
 +	}
 +	if (c == EOF && !n) {

--- a/rstr.patch
+++ b/rstr.patch
@@ -104,7 +104,7 @@ index 8cd63f7..7c125c0 100644
  			int g1 = offs[grp - 2], g2 = offs[grp - 1];
  			if (g1 < 0) {
 diff --git a/regex.c b/regex.c
-index 51d54a4..39e6215 100644
+index 51d54a4..3e8ea6b 100644
 --- a/regex.c
 +++ b/regex.c
 @@ -656,3 +656,126 @@ char *re_read(char **src)
@@ -138,7 +138,7 @@ index 51d54a4..39e6215 100644
 +	if (!re[0]) {
 +		int len = end - beg;
 +		rs->len = len;
-+		rs->str = malloc(len + 1);
++		rs->str = emalloc(len + 1);
 +		rs->str[len] = '\0';
 +		if (icase) {
 +			while (--len >= 0)
@@ -152,7 +152,7 @@ index 51d54a4..39e6215 100644
 +
 +rstr *rstr_make(char *re, int flg)
 +{
-+	rstr *rs = malloc(sizeof(*rs));
++	rstr *rs = emalloc(sizeof(*rs));
 +	memset(rs, 0, sizeof(*rs));
 +	rs->icase = flg & REG_ICASE;
 +	if (rstr_simple(rs, re, rs->icase))


### PR DESCRIPTION
I saw the error checked malloc pr and figured it would be a good idea to update any optional patches that use malloc/realloc so they use the error checked versions