### PR TITLE
exrc.patch: small rework and some bugfixes

### DIFF
--- a/exrc.patch
+++ b/exrc.patch
@@ -1,12 +1,12 @@
 diff --git a/ex.c b/ex.c
-index fff5d34..73515e6 100644
+index fff5d34..b3418b1 100644
 --- a/ex.c
 +++ b/ex.c
 @@ -22,6 +22,7 @@ int xpac;			/* print autocomplete options */
  int xkwdcnt;			/* number of search kwd changes */
  int xbufcur;			/* number of active buffers */
  int xgrec;			/* global vi/ex recursion depth */
-+int xexrc;			/* read .exrc from the current directory */
++int xexrc = 0;			/* read .exrc from the current directory */
  struct buf *bufs;		/* main buffers */
  struct buf tempbufs[2];		/* temporary buffers, for internal use */
  struct buf *ex_buf;		/* current buffer */
@@ -18,25 +18,33 @@ index fff5d34..73515e6 100644
  	{"hl", &xhl},
  	{"hll", &xhll},
  	{"hlw", &xhlw},
-@@ -1183,6 +1185,47 @@ void ex(void)
+@@ -1183,6 +1185,51 @@ void ex(void)
  	xgrec--;
  }
  
-+char *load_line(FILE *fp)
++void ex_script(FILE *fp)
 +{
-+	char *ln = NULL;
-+	int n = 0;
-+	int c;
-+	while ((c = fgetc(fp)) != EOF && c != '\n') {
-+		ln = erealloc(ln, n + 2);
-+		ln[n++] = c;
-+	}
-+	if (c == EOF && !n) {
++	char done = 0;
++	do {
++		size_t n = 128, i = 0;
++		int c;
++		char *ln = malloc(128);
++		while ((c = fgetc(fp)) != EOF && c != '\n') {
++			if (i >= n - 2) {
++				n += 128;
++				ln = erealloc(ln, n);
++			}
++			ln[i++] = c;
++		}
++		if (!i) {
++			free(ln);
++			done = 1;
++			break;
++		}
++		ln[i] = '\0';
++		ex_command(ln);
 +		free(ln);
-+		return NULL;
-+	}
-+	ln[n] = '\0';
-+	return ln;
++	} while(!done);
 +}
 +
 +void load_exrc(char *exrc)
@@ -46,11 +54,7 @@ index fff5d34..73515e6 100644
 +		if (st.st_uid == getuid() && !(st.st_mode & S_IWGRP) && !(st.st_mode & S_IWOTH)) {
 +			FILE *fp = fopen(exrc, "r");
 +			if (fp) {
-+				char *ln = NULL;
-+				while ((ln = load_line(fp))) {
-+					ex_command(ln);
-+					free(ln);
-+				}
++				ex_script(fp);
 +				fclose(fp);
 +			} else {
 +				fprintf(stderr, "Cannot open ~/.exrc\n");
@@ -66,7 +70,7 @@ index fff5d34..73515e6 100644
  void ex_init(char **files, int n)
  {
  	xbufsalloc = MAX(n, xbufsalloc);
-@@ -1194,6 +1237,16 @@ void ex_init(char **files, int n)
+@@ -1194,6 +1241,20 @@ void ex_init(char **files, int n)
  	} while (--n > 0);
  	xmpt = 0;
  	xvis &= ~8;
@@ -81,8 +85,12 @@ index fff5d34..73515e6 100644
 +			load_exrc(exrc);
 +		}
 +	}
-+	if (xexrc && strcmp(getcwd(NULL, 0), getenv("HOME")))
-+		load_exrc(".exrc");
++	if (xexrc) {
++		char buf[PATH_MAX];
++		getcwd(buf, PATH_MAX);
++		if (strcmp(buf, getenv("HOME")) != 0)
++			load_exrc(".exrc");
++	}
  }
 diff --git a/vi.c b/vi.c
 index 860ebee..6a370d4 100644


### PR DESCRIPTION
Fixes a memory leak where getcwd was called with a NULL buf and the returned memory was not freed

Fix xexrc being unitialized