### PR TITLE
fix compiler warn

### DIFF
--- a/vi.c
+++ b/vi.c
@@ -1209,7 +1209,7 @@ static void vc_status(int type)
 		uc_code(cp, c, l)
 		memcpy(cbuf, c, l);
 		snprintf(vi_msg, sizeof(vi_msg), "<%s> %08x S%ld O%d C%d",
-			cbuf, cp, *c ? c - lbuf_get(xb, xrow) : 0, xoff,
+			cbuf, cp, *c ? c - lbuf_get(xb, xrow) : 0L, xoff,
 			ren_cursor(lbuf_get(xb, xrow), col) + 1);
 		return;
 	}


### PR DESCRIPTION
```
vi.c:1212:14: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]
 1211 |                 snprintf(vi_msg, sizeof(vi_msg), "<%s> %08x S%ld O%d C%d",
      |                                                              ~~~
      |                                                              %d
 1212 |                         cbuf, cp, *c ? c - lbuf_get(xb, xrow) : 0, xoff,
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```