### PR TITLE
Fixed warnings

### DIFF
--- a/led.c
+++ b/led.c
@@ -393,7 +393,7 @@ static void led_redraw(char *cs, int r, int orow, int lsh)
 	rstate--;
 }
 
-void led_modeswap()
+void led_modeswap(void)
 {
 	preserve(int, xvis, xvis & 4 ? xvis & ~4 : xvis | 4)
 	preserve(int, ftidx, ftidx)

--- a/vi.h
+++ b/vi.h
@@ -340,7 +340,7 @@ typedef struct {
 	int att;
 } led_att;
 extern sbuf *led_attsb;
-void led_modeswap();
+void led_modeswap(void);
 void led_prompt(sbuf *sb, char *insert, int *kmap, int *key, int ps, int hist);
 void led_input(sbuf *sb, char **post, int postn, int row, int lsh);
 void led_render(char *s0, int cbeg, int cend);


### PR DESCRIPTION
```
In file included from vi.c:16:
./vi.h:343:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  343 | void led_modeswap();
      |                  ^
      |                   void
In file included from vi.c:20:
./led.c:396:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  396 | void led_modeswap()
      |                  ^
      |                   void
2 warnings generated.
