### PR TITLE
add FILE and DIR types to highlight list

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -65,7 +65,7 @@ struct highlight hls[] = {
 		A(BL | SYN_IT, BL | SYN_BS, BL | SYN_BE)},
 	{FT(c), NULL, A(RE1 | SYN_BGMK(BL1)), 0, 3},
 	{FT(c), NULL, A(RE1), 0, 1},
-	{FT(c), "\\<(?:signed|unsigned|char|short|u?int(?:64_t|32_t|16_t|8_t)?|FILE|DIR|\
+	{FT(c), "\\<(?:signed|unsigned|char|short|int|[a-z0-9_]+_t|FILE|DIR|\
 long|f(?:loat|64|32)|double|void|enum|union|typedef|static|extern|register|struct|\
 s(?:64|32|16|8)|u(?:64|32|16|8)|b32|bool|const|size_t|inline|restrict|\
 (true|false|_?_?asm_?_?|mem(?:set|cpy|cmp)|malloc|free|realloc|NULL|std(?:in|\


### PR DESCRIPTION
I was gonna also add all the stdint types but there's too many, would there be any major conflicts by just highlighting anything that ends with _t?  I don't know how to do that in this regex impl anyway tho.
Also would it be possible to highlight all functions by just checking for a word followed by opening and closing parenthesis?  Would be a lot nicer then just highlighting a few hardcoded common libc functions.