### PR TITLE
fix for (potential) bug with scrolling

### DIFF
--- a/vi.c
+++ b/vi.c
@@ -1182,8 +1182,7 @@ if (xtop > xrow) \
 	xtop = xtop - xrows / 2 > xrow ? \
 			MAX(0, xrow - xrows / 2) : xrow; \
 if (xtop + xrows <= xrow) \
-	xtop = xtop + xrows + xrows / 2 <= xrow ? \
-			xrow - xrows / 2 : xrow - xrows + 1; \
+	xtop = xrow - xrows + 1; \
 
 void vi(int init)
 {


### PR DESCRIPTION
Hi, thanks for merging my pull request for the markdown highlighting. Apologies for the original pull request getting closed I had some issues with my GitHub account, should be all sorted now.

I figured out how to fix some behavior I noticed, where moving down many lines at once (for example `1000j`, or `G`), will cause the screen to scroll too far leaving blank (`~`) lines at the bottom.

This might be intentional behavior I'm not 100% sure