### PR TITLE
exrc patch update

### DIFF
--- a/ex.c
+++ b/ex.c
@@ -1,3 +1,4 @@
+int xexrc = 0;			/* read .exrc from the current directory */
 int xleft;			/* the first visible column */
 int xvis;			/* startup flags */
 int xai = 1;			/* autoindent option */
@@ -1474,6 +1475,7 @@ static void *eo_##opt(char *loc, char *cmd, char *arg) { inner }
 EO(pac) EO(pr) EO(ai) EO(err) EO(ish) EO(ic) EO(mpt)
 EO(shape) EO(seq) EO(ts) EO(td) EO(order) EO(hll) EO(hlw)
 EO(hlp) EO(hlr) EO(hl) EO(lim) EO(led) EO(vis)
+EO(exrc)
 
 _EO(grp, xgrp = (!*arg ? !xgrp : eo_val(arg)) * 2; return NULL;)
 
@@ -1517,6 +1519,7 @@ static struct excmd {
 	EO(ai),
 	{"ac", ec_setacreg},
 	{"a", ec_insert},
+	EO(exrc),
 	EO(err),
 	{"ef!", ec_fuzz},
 	{"ef", ec_fuzz},
@@ -1742,6 +1745,55 @@ void ex(void)
 	xgrec--;
 }
 
+void ex_script(FILE *fp)
+{
+	char done = 0;
+	do {
+		size_t n = 128, i = 0;
+		int c;
+		char *ln = malloc(128);
+		while ((c = fgetc(fp)) != EOF && c != '\n') {
+			if (i >= n - 2) {
+				n += 128;
+				ln = erealloc(ln, n);
+			}
+			ln[i++] = c;
+		}
+		if (c == EOF) {
+			free(ln);
+			done = 1;
+			break;
+		}
+		if (ln[0] != '#' && ln[0] != '\n') { /* not a comment or empty line */
+			ln[i] = '\0';
+			ex_command(ln);
+		}
+		free(ln);
+	} while(!done);
+}
+
+int load_exrc(char *exrc)
+{
+	struct stat st;
+	if (stat(exrc, &st) == 0) {
+		if (st.st_uid == getuid() && !(st.st_mode & S_IWGRP) && !(st.st_mode & S_IWOTH)) {
+			FILE *fp = fopen(exrc, "r");
+			if (fp) {
+				ex_script(fp);
+				fclose(fp);
+			} else {
+				fprintf(stderr, "Cannot open %s\n", exrc);
+				exit(EXIT_FAILURE);
+			}
+		} else {
+			fprintf(stderr, "Bad permissions on %s\n", exrc);
+			exit(EXIT_FAILURE);
+		}
+	} else
+		return 1;
+	return 0;
+}
+
 void ex_init(char **files, int n)
 {
 	xbufsalloc = MAX(n, xbufsalloc);
@@ -1753,6 +1805,29 @@ void ex_init(char **files, int n)
 		s = *(++files);
 	} while (--n > 0);
 	xvis &= ~4;
-	if ((s = getenv("EXINIT")))
+	if ((s = getenv("EXINIT"))) {
 		ex_command(s)
+	} else {
+		char exrc[PATH_MAX];
+		char *homeenv = getenv("HOME");
+		char *xdgconfighomeenv = getenv("XDG_CONFIG_HOME");
+		if (xdgconfighomeenv) {
+			snprintf(exrc, sizeof(exrc), "%s/nextvi/exrc", xdgconfighomeenv);
+			if (!load_exrc(exrc))
+				homeenv = NULL;
+		}
+		if (homeenv) {
+			snprintf(exrc, sizeof(exrc), "%s/.config/nextvi/exrc", homeenv);
+			if (load_exrc(exrc)) {
+				snprintf(exrc, sizeof(exrc), "%s/.exrc", homeenv);
+				load_exrc(exrc);
+			}
+		}
+	}
+	if (xexrc) {
+		char buf[PATH_MAX];
+		getcwd(buf, PATH_MAX);
+		if (strcmp(buf, getenv("HOME")) != 0)
+			load_exrc(".exrc");
+	}
 }


### PR DESCRIPTION
IDK how to work with your custom patch format so the diff is just the whole new patch.
There are 2 changes
1. previously the script would treat an empty line as EOF and ignore any commands after it, now empty lines are skipped normally.
2. There used to be no way to have comments (unless I missed something in the spec), which is a huge annoyance since I am *not* remembering what `&3^'` does.  Now any line starting with # is skipped so you can write comments by starting the line with #.