### PR TITLE
extend list of heap allocation functions

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -76,7 +76,8 @@ struct highlight hls[] = {
 		A(BL | SYN_IT, BL | SYN_BLK, SYN_BSE | SYN_BEDP, BL | SYN_BLK, SYN_BSE | SYN_BSD)},
 	{FT(c), "\\<(?:signed|unsigned|char|short|int|[a-z0-9_]+_t|FILE|DIR|long|f(?:loat|64|32)|\
 double|void|enum|union|typedef|static|extern|register|struct|s(?:64|32|16|8)|u(?:64|32|16|8)|b32|\
-bool|const|inline|restrict|auto|(true|false|_?_?asm_?_?|mem(?:set|cpy|cmp)|malloc|free|realloc|\
+bool|const|inline|restrict|auto|(true|false|_?_?asm_?_?|mem(?:set|cpy|cmp)|free|(posix_)?memalign|\
+(m|c|v|re|aligned_)alloc|realloc(f|array)|\
 NULL|std(?:in|out|err)|errno)|(return|for|while|if|else|do|sizeof|goto|switch|case|default|break|\
 continue))\\>", A(GR1, BL1 | SYN_BD, YE1)},
 	{FT(c), "//.*", A(BL | SYN_IT)},

--- a/ex.c
+++ b/ex.c
@@ -24,7 +24,8 @@ int xerr = 1;			/* error handling -
 int xfr;			/* ec_find register */
 int xrr;			/* record register */
 
-int xquit;			/* exit if positive, force quit if negative */
+int xquit;			/* exit if positive, force quit if -1,
+				counted led_modeswap unwind if < -1 */
 int xrow, xoff, xtop;		/* current row, column, and top row */
 int xbufcur;			/* number of active buffers */
 int xgrec;			/* global vi/ex recursion depth */
@@ -653,7 +654,7 @@ static void *ec_quit(char *loc, char *cmd, char *arg)
 	if (*arg)
 		xquit = abs(atoi(arg)) + 1;
 	if (strchr(cmd, '!'))
-		xquit = -xquit;
+		xquit = -1;
 	return NULL;
 }
 

--- a/led.c
+++ b/led.c
@@ -412,8 +412,10 @@ void led_modeswap(void)
 		syn_setft(xb_ft);
 		vi(1);
 	}
-	if (xquit > 0)
+	if (xquit > 0 || xquit == -2)
 		restore(xquit)
+	else if (xquit < -2)
+		xquit++;
 	restore(texec)
 	restore(xvis)
 	restore(xexec_dep)

--- a/vi.c
+++ b/vi.c
@@ -1693,7 +1693,7 @@ void vi(int init)
 					ex_exec("x");
 					continue;
 				}
-				xquit = texec == '&' ? -1 : 1;
+				xquit = vi_arg ? -vi_arg - 2 : 1;
 				if (k == 'z')
 					term_push("\n", 1);
 				else if (xgrec == 1) {
@@ -1880,5 +1880,5 @@ int main(int argc, char *argv[])
 	term_done();
 	if (xvis & 8)
 		term_scrl;
-	return abs(xquit) - 1;
+	return xquit < 0 ? 0 : xquit - 1;
 }


### PR DESCRIPTION
added the following functions:
- POSIX/C
  - calloc
  - aligned_alloc
  - posix_memalign
  - valloc
- GNU
  - memalign
  - reallocarray
- BSD
  - reallocf

Is there a way to add to this list at runtime with ex commands?  That would be useful for the current project I've been working on, where almost all malloc calls are done through a wrapper called safeMalloc that aborts if the allocation fails.  It seems to me like just obvious enough of a usecase that it might already exist, but I didn't see anything that looked like that when grepping through the spec or patches.